### PR TITLE
adding device selection and OpenCL buffer operations

### DIFF
--- a/compute_samples/applications/usm_hello_world/include/usm_hello_world/usm_hello_world.hpp
+++ b/compute_samples/applications/usm_hello_world/include/usm_hello_world/usm_hello_world.hpp
@@ -24,13 +24,15 @@ private:
     bool help = false;
     boost::compute::usm_type type = boost::compute::usm_type::host;
     size_t size = 0;
+    size_t device = 0;
   };
   Arguments
   parse_command_line(const std::vector<std::string> &command_line) const;
 };
 
 std::vector<cl_uint> copy_buffer(const std::vector<cl_uint> &input,
-                                 const boost::compute::usm_type type);
+                                 const boost::compute::usm_type type,
+                                 const size_t device_num);
 
 } // namespace compute_samples
 

--- a/compute_samples/applications/usm_hello_world/src/usm_hello_world.cpp
+++ b/compute_samples/applications/usm_hello_world/src/usm_hello_world.cpp
@@ -32,36 +32,47 @@ Application::Status UsmHelloWorldApplication::run_implementation(
     return Status::SKIP;
   }
 
-  const compute::device_intel device(compute::system::default_device());
+  LOG_INFO << "OpenCL device count: " << compute::system::device_count();
+  size_t iter = 0;
+  for (const auto &device : boost::compute::system::devices()) {
+    LOG_INFO << " " << iter++ << " --> " << device.name();
+  }
+  const compute::device_intel device(compute::system::find_device(boost::compute::system::devices()[args.device].name()));
   LOG_INFO << "OpenCL device: " << device.name();
 
-  if (!device.supports_extension("cl_intel_unified_shared_memory_preview")) {
-    LOG_ERROR << "cl_intel_unified_shared_memory_preview extension is required";
-    return Status::SKIP;
-  }
+  if (args.type != compute::usm_type::unknown) {
+    if (!device.supports_extension("cl_intel_unified_shared_memory_preview")) {
+      LOG_ERROR
+          << "cl_intel_unified_shared_memory_preview extension is required";
+      return Status::SKIP;
+    }
 
-  cl_unified_shared_memory_capabilities_intel capabilities = 0;
-  if (args.type == compute::usm_type::host) {
-    capabilities = device.host_mem_capabilities();
-  } else if (args.type == compute::usm_type::device) {
-    capabilities = device.device_mem_capabilities();
-  } else if (args.type == compute::usm_type::shared) {
-    capabilities = device.single_device_shared_mem_capabilities();
-  }
+    cl_unified_shared_memory_capabilities_intel capabilities = 0;
+    if (args.type == compute::usm_type::host) {
+      capabilities = device.host_mem_capabilities();
+    } else if (args.type == compute::usm_type::device) {
+      capabilities = device.device_mem_capabilities();
+    } else if (args.type == compute::usm_type::shared) {
+      capabilities = device.single_device_shared_mem_capabilities();
+    }
 
-  if ((capabilities & CL_UNIFIED_SHARED_MEMORY_ACCESS_INTEL) == 0u) {
-    LOG_ERROR << "CL_UNIFIED_SHARED_MEMORY_ACCESS_INTEL capability is required";
-    return Status::SKIP;
+    if ((capabilities & CL_UNIFIED_SHARED_MEMORY_ACCESS_INTEL) == 0u) {
+      LOG_ERROR
+          << "CL_UNIFIED_SHARED_MEMORY_ACCESS_INTEL capability is required";
+      return Status::SKIP;
+    }
   }
-
   LOG_INFO << "Allocation size: " << args.size;
+  if (args.type == compute::usm_type::unknown) {
+    LOG_INFO << "OpenCL Buffer type used";
+  } else
   LOG_INFO << "Unified shared memory type: " << args.type;
 
   std::vector<cl_uint> input(args.size);
   std::iota(input.begin(), input.end(), 0u);
 
   Timer timer_total;
-  copy_buffer(input, args.type);
+  copy_buffer(input, args.type, args.device);
   timer_total.print("Total");
 
   return Status::OK;
@@ -76,9 +87,11 @@ UsmHelloWorldApplication::parse_command_line(
   auto options = desc.add_options();
   options("help,h", "show help message");
   options("type", po::value<compute::usm_type>(&args.type)->required(),
-          "unified shared memory type: host, device or shared");
+          "unified shared memory type: host, device or shared, unknown for clEnqueueWriteBuffer/clEnqueueReadBuffer");
   options("size", po::value<size_t>(&args.size)->default_value(1024 * 1024),
           "number of elements to allocate");
+  options("device", po::value<size_t>(&args.device)->default_value(0),
+          "device to run at");
 
   po::positional_options_description p;
   p.add("type", 1);
@@ -99,45 +112,60 @@ UsmHelloWorldApplication::parse_command_line(
 }
 
 std::vector<cl_uint> copy_buffer(const std::vector<cl_uint> &input,
-                                 const compute::usm_type type) {
+                                 const compute::usm_type type,
+                                 const size_t device_num) {
 
-  const compute::device device = compute::system::default_device();
-  compute::context context(compute::system::default_context());
-  compute::command_queue_intel queue(compute::system::default_queue());
+  const compute::device device = compute::system::find_device(boost::compute::system::devices()[device_num].name());
+  compute::context context(device);
+  compute::command_queue_intel queue(context, device);
 
   Timer timer;
 
   cl_uint *input_mem = nullptr;
   cl_uint *output_mem = nullptr;
-  if (type == compute::usm_type::host) {
-    input_mem =
-        compute::host_mem_alloc<cl_uint>(context, nullptr, input.size(), 0);
-    output_mem =
-        compute::host_mem_alloc<cl_uint>(context, nullptr, input.size(), 0);
-  } else if (type == compute::usm_type::device) {
-    input_mem = compute::device_mem_alloc<cl_uint>(context, device, nullptr,
-                                                   input.size(), 0);
-    output_mem = compute::device_mem_alloc<cl_uint>(context, device, nullptr,
-                                                    input.size(), 0);
-  } else if (type == compute::usm_type::shared) {
-    input_mem = compute::shared_mem_alloc<cl_uint>(context, device, nullptr,
-                                                   input.size(), 0);
-    output_mem = compute::shared_mem_alloc<cl_uint>(context, device, nullptr,
-                                                    input.size(), 0);
+  if (type == compute::usm_type::unknown) {
+    input_mem = (cl_uint *) new compute::buffer(context, size_in_bytes(input));
+    output_mem = (cl_uint *) new compute::buffer(context, size_in_bytes(input));
+    timer.print("OCL buffer allocated");
   }
-  timer.print("Unified shared memory allocated");
-
+  else{
+      if (type == compute::usm_type::host) {
+        input_mem =
+            compute::host_mem_alloc<cl_uint>(context, nullptr, input.size(), 0);
+        output_mem =
+            compute::host_mem_alloc<cl_uint>(context, nullptr, input.size(), 0);
+      } else if (type == compute::usm_type::device) {
+        input_mem = compute::device_mem_alloc<cl_uint>(context, device, nullptr,
+                                                       input.size(), 0);
+        output_mem = compute::device_mem_alloc<cl_uint>(context, device, nullptr,
+                                                        input.size(), 0);
+      } else if (type == compute::usm_type::shared) {
+        input_mem = compute::shared_mem_alloc<cl_uint>(context, device, nullptr,
+                                                       input.size(), 0);
+        output_mem = compute::shared_mem_alloc<cl_uint>(context, device, nullptr,
+                                                        input.size(), 0);
+      }
+      timer.print("Unified shared memory allocated");
+  }
   if (type == compute::usm_type::host || type == compute::usm_type::shared) {
     std::copy(input.begin(), input.end(), input_mem);
   } else if (type == compute::usm_type::device) {
     queue.enqueue_memcpy(input_mem, input.data(), size_in_bytes(input));
+  } else if (type == compute::usm_type::unknown) {
+    queue.enqueue_write_buffer(*(compute::buffer*)input_mem, 0, size_in_bytes(input), input.data());
   }
   timer.print("Input copied");
 
   compute::program program = build_program(context, "usm_hello_world.cl");
   compute::kernel_intel kernel(program.create_kernel("usm_hello_world_kernel"));
-  kernel.set_arg_mem_ptr(0, input_mem);
-  kernel.set_arg_mem_ptr(1, output_mem);
+  if (type == compute::usm_type::unknown) {
+      kernel.set_arg(0, *(compute::buffer*)input_mem);
+      kernel.set_arg(1, *(compute::buffer*)output_mem);
+  }
+  else{
+      kernel.set_arg_mem_ptr(0, input_mem);
+      kernel.set_arg_mem_ptr(1, output_mem);
+  }
   timer.print("Kernel prepared");
 
   queue.enqueue_1d_range_kernel(kernel, 0, input.size(), 0);
@@ -150,13 +178,22 @@ std::vector<cl_uint> copy_buffer(const std::vector<cl_uint> &input,
   } else if (type == compute::usm_type::device) {
     output = std::vector<cl_uint>(input.size());
     queue.enqueue_memcpy(output.data(), output_mem, size_in_bytes(output));
+  } else if (type == compute::usm_type::unknown) {
+    output = std::vector<cl_uint>(input.size());
+    compute::buffer* in ((compute::buffer*)output_mem);
+    queue.enqueue_read_buffer(*in, 0, size_in_bytes(output), output.data());
   }
   timer.print("Output copied");
 
-  compute::mem_free(context, output_mem);
-  compute::mem_free(context, input_mem);
-  timer.print("Unified shared memory freed");
-
+  if (type == compute::usm_type::unknown) {
+      delete (compute::buffer*)output_mem;
+      delete (compute::buffer*)input_mem;
+      timer.print("OCL buffer memory freed");
+  } else {
+      compute::mem_free(context, output_mem);
+      compute::mem_free(context, input_mem);
+      timer.print("Unified shared memory freed");
+  }
   return output;
 }
 

--- a/compute_samples/applications/usm_hello_world/test/usm_hello_world_integration_tests.cpp
+++ b/compute_samples/applications/usm_hello_world/test/usm_hello_world_integration_tests.cpp
@@ -24,7 +24,7 @@ HWTEST(UsmHelloWorldIntegrationTests, CopyBufferWithHostUsm) {
   std::vector<cl_uint> input(1024);
   std::iota(input.begin(), input.end(), 0u);
   const std::vector<cl_uint> output =
-      cs::copy_buffer(input, compute::usm_type::host);
+      cs::copy_buffer(input, compute::usm_type::host, (size_t)0);
   EXPECT_EQ(input, output);
 }
 
@@ -32,7 +32,7 @@ HWTEST(UsmHelloWorldIntegrationTests, CopyBufferWithDeviceUsm) {
   std::vector<cl_uint> input(1024);
   std::iota(input.begin(), input.end(), 0u);
   const std::vector<cl_uint> output =
-      cs::copy_buffer(input, compute::usm_type::device);
+      cs::copy_buffer(input, compute::usm_type::device, (size_t)0);
   EXPECT_EQ(input, output);
 }
 
@@ -40,6 +40,6 @@ HWTEST(UsmHelloWorldIntegrationTests, CopyBufferWithSharedUsm) {
   std::vector<cl_uint> input(1024);
   std::iota(input.begin(), input.end(), 0u);
   const std::vector<cl_uint> output =
-      cs::copy_buffer(input, compute::usm_type::shared);
+      cs::copy_buffer(input, compute::usm_type::shared, (size_t)0);
   EXPECT_EQ(input, output);
 }

--- a/compute_samples/core/ocl_utils/src/unified_shared_memory.cpp
+++ b/compute_samples/core/ocl_utils/src/unified_shared_memory.cpp
@@ -39,6 +39,8 @@ std::istream &operator>>(std::istream &is, compute::usm_type &x) {
     x = compute::usm_type::device;
   } else if (s == "shared") {
     x = compute::usm_type::shared;
+  } else if (s == "unknown") {
+    x = compute::usm_type::unknown;
   } else {
     is.setstate(std::ios_base::failbit);
   }


### PR DESCRIPTION
- usm_type::unknown can be used for non-intrusive flagging of OpenCL buffer operations to be used

- OpenCL device selection added with by: --device N
flag where N indicates the device, device count is shown with names and indexes